### PR TITLE
Add PBCS to allowed values for Manifest API

### DIFF
--- a/pbshipping/models/carrier.py
+++ b/pbshipping/models/carrier.py
@@ -35,8 +35,9 @@ class Carrier(object):
     PBI = "PBI"
     FEDEX = "FEDEX"
     USP = "USP"
+    PBCS = "PBCS"
 
-    allowable_values = [USPS, PBPRESORT, NEWGISTICS, PBI, FEDEX, USP]  # noqa: E501
+    allowable_values = [USPS, PBPRESORT, NEWGISTICS, PBI, FEDEX, USP, PBCS]  # noqa: E501
 
     """
     Attributes:

--- a/pbshipping/models/manifest.py
+++ b/pbshipping/models/manifest.py
@@ -111,8 +111,8 @@ class Manifest(object):
         """
         if self.local_vars_configuration.client_side_validation and carrier is None:  # noqa: E501
             raise ValueError("Invalid value for `carrier`, must not be `None`")  # noqa: E501
-        allowed_values = ["USPS", "NEWGISTICS", "PBPresort"]  # noqa: E501
-        if self.local_vars_configuration.client_side_validation and carrier not in allowed_values:  # noqa: E501
+        allowed_values = ["USPS", "NEWGISTICS", "PBPRESORT", "PBCS"]  # noqa: E501
+        if self.local_vars_configuration.client_side_validation and carrier.upper() not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `carrier` ({0}), must be one of {1}"  # noqa: E501
                 .format(carrier, allowed_values)


### PR DESCRIPTION
This PR updates the validation logic to allow "PBCS" to be used as the value for carrier in the Manifest API. It also handles an issue where the Manifest API always returns the carrier name in lowercase.

See: https://docs.shippingapi.pitneybowes.com/api/post-manifests-pitney-bowes.html#request-response-elements