### PR TITLE
Fix postal code casting in tracking response scan details list.

### DIFF
--- a/pbshipping/models/tracking_response_scan_details_list.py
+++ b/pbshipping/models/tracking_response_scan_details_list.py
@@ -39,7 +39,7 @@ class TrackingResponseScanDetailsList(object):
         'event_time_offset': 'str',
         'event_city': 'str',
         'event_state_or_province': 'str',
-        'postal_code': 'int',
+        'postal_code': 'str',
         'country': 'str',
         'scan_type': 'str',
         'scan_description': 'str',


### PR DESCRIPTION
Postal code is returned as `str` and not `int`